### PR TITLE
Support custom default mode mappings

### DIFF
--- a/classes/cache_administration_helper.php
+++ b/classes/cache_administration_helper.php
@@ -96,6 +96,7 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         $html .= $renderer->definition_summaries($definitionsummaries, $context);
         $html .= $renderer->lock_summaries($locks);
         $html .= $this->get_ruleset_output();
+        $html .= $this->get_mode_mappings_output();
 
         return $html;
     }
@@ -264,6 +265,39 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
             $html .= html_writer::table($table);
         }
         return html_writer::tag('p', $html);
+    }
+
+    public function get_mode_mappings_output() {
+        global $OUTPUT;
+        $defaultmodestores = $this->get_default_mode_stores();
+        $applicationstore = join(', ', $defaultmodestores[cache_store::MODE_APPLICATION]);
+        $sessionstore = join(', ', $defaultmodestores[cache_store::MODE_SESSION]);
+        $requeststore = join(', ', $defaultmodestores[cache_store::MODE_REQUEST]);
+        $table = new html_table();
+        $table->colclasses = array(
+            'mode',
+            'mapping',
+        );
+        $table->rowclasses = array(
+            'mode_application',
+            'mode_session',
+            'mode_request'
+        );
+        $table->head = array(
+            get_string('mode', 'cache'),
+            get_string('mappings', 'cache'),
+        );
+        $table->data = array(
+            array(get_string('mode_'.cache_store::MODE_APPLICATION, 'cache'), $applicationstore),
+            array(get_string('mode_'.cache_store::MODE_SESSION, 'cache'), $sessionstore),
+            array(get_string('mode_'.cache_store::MODE_REQUEST, 'cache'), $requeststore)
+        );
+
+        $html = html_writer::start_tag('div', array('id' => 'core-cache-mode-mappings'));
+        $html .= $OUTPUT->heading(get_string('defaultmappings', 'cache'), 3);
+        $html .= html_writer::table($table);
+        $html .= html_writer::end_tag('div');
+        return $html;
     }
 
     /**

--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -98,7 +98,10 @@ class tool_forcedcache_cache_config extends cache_config {
         $stores = $this->generate_store_instance_config($config['stores']);
 
         // Generate the mode mappings.
-        $modemappings = $this->generate_mode_mapping($config['rules']);
+        if (!isset($config['modemappings'])) {
+            $config['modemappings'] = [];
+        }
+        $modemappings = $this->generate_mode_mapping($config['modemappings']);
 
         // Get the definitions.
         $definitions = $this->apply_definition_overrides(tool_forcedcache_cache_config_writer::locate_definitions(),
@@ -252,7 +255,7 @@ class tool_forcedcache_cache_config extends cache_config {
      *
      * @return array the generated default mode mappings.
      */
-    private function generate_mode_mapping() : array {
+    private function generate_mode_mapping($mappings) : array {
         // Use the defaults from core.
         $modemappings = array(
             array(
@@ -271,6 +274,18 @@ class tool_forcedcache_cache_config extends cache_config {
                 'sort' => -1
             )
         );
+
+        $modetostr = [
+            cache_store::MODE_APPLICATION => 'application',
+            cache_store::MODE_SESSION => 'session',
+            cache_store::MODE_REQUEST => 'request',
+        ];
+        foreach ($modemappings as $key => $map) {
+            $mode = $modetostr[$map['mode']];
+            if (isset($mappings[$mode])) {
+                $modemappings[$key]['store'] = $mappings[$mode];
+            }
+        }
 
         return $modemappings;
     }


### PR DESCRIPTION
Without this it is impossible to set default mode mappings as it forces it to
the default ones from core.

This makes it possible to specify the store to use in config. The following
example shows how you would switch from using `default_application` to
`somestore` for MODE_APPLICATION stores.
```
$CFG->tool_forcedcache_config_array = [
  'stores' => [
    'somestore' => [ ... ],
  ],
  'modemappings' => [
    'application' => 'somestore',
  ],
];
```

This functionality is useful when using $CFG->enable_read_only_sessions - as
adhoc session stores would otherwise store data in the default_session store -
which triggers an immediate error for the user they can't escape in M3.11+
without killing their session.