### PR TITLE
Add a check to ensure the JSON config is outside of the $CFG->dirroot

### DIFF
--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -171,6 +171,12 @@ class tool_forcedcache_cache_config extends cache_config {
             $path = __DIR__.'/../config.json';
         }
 
+        // If the json file path is inside dirroot, throw an exception. This
+        // should not be allowed as it would expose the configuration.
+        if (!empty($path) && strpos($path, $CFG->dirroot) !== false) {
+            throw new cache_exception(get_string('config_json_path_invalid', 'tool_forcedcache', $CFG->dirroot));
+        }
+
         // Now try to load the JSON.
         if (file_exists($path)) {
             $filedata = file_get_contents($path);

--- a/lang/en/tool_forcedcache.php
+++ b/lang/en/tool_forcedcache.php
@@ -31,6 +31,7 @@ $string['page_active'] = 'Forced cache configuration IS active.';
 $string['config_json_parse_fail'] = 'Error parsing JSON to array. JSON syntax may be malformed.';
 $string['config_array_parse_fail'] = 'Error parsing configuration array. Array syntax may be malformed.';
 $string['config_json_missing'] = 'Error reading specified JSON file. File may not exist, or path is incorrect.';
+$string['config_json_path_invalid'] = 'Invalid configuration path. Please ensure the path is outside of the "{$a}" directory.';
 $string['config_path_and_array'] = 'Detected both path to file and config array. Only one can be specified.';
 $string['definition_not_found'] = 'Definition not defined for configuration override: {$a}.';
 $string['store_missing_fields'] = 'Error reading store {$a}, it may be missing fields or malformed.';


### PR DESCRIPTION
Closes #25 

- This is to prevent the ability of viewing the configuration file directly from the web, where it may expose configuration and various connection settings.

Example error shown:

![image](https://user-images.githubusercontent.com/9924643/140838998-1b7f4d8c-fe3d-479f-bc2d-5c1421510c0a.png)

Please let me know if it should just specify the `$CFG->dirroot` string instead of displaying the path.