### PR TITLE
Add support for default mode mappings

### DIFF
--- a/classes/cache_administration_helper.php
+++ b/classes/cache_administration_helper.php
@@ -96,6 +96,7 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
         $html .= $renderer->definition_summaries($definitionsummaries, $context);
         $html .= $renderer->lock_summaries($locks);
         $html .= $this->get_ruleset_output();
+        $html .= $this->get_mode_mappings_output();
 
         return $html;
     }
@@ -264,6 +265,39 @@ class tool_forcedcache_cache_administration_helper extends core_cache\administra
             $html .= html_writer::table($table);
         }
         return html_writer::tag('p', $html);
+    }
+
+    public function get_mode_mappings_output() {
+        global $OUTPUT;
+        $defaultmodestores = $this->get_default_mode_stores();
+        $applicationstore = join(', ', $defaultmodestores[cache_store::MODE_APPLICATION]);
+        $sessionstore = join(', ', $defaultmodestores[cache_store::MODE_SESSION]);
+        $requeststore = join(', ', $defaultmodestores[cache_store::MODE_REQUEST]);
+        $table = new html_table();
+        $table->colclasses = array(
+            'mode',
+            'mapping',
+        );
+        $table->rowclasses = array(
+            'mode_application',
+            'mode_session',
+            'mode_request'
+        );
+        $table->head = array(
+            get_string('mode', 'cache'),
+            get_string('mappings', 'cache'),
+        );
+        $table->data = array(
+            array(get_string('mode_'.cache_store::MODE_APPLICATION, 'cache'), $applicationstore),
+            array(get_string('mode_'.cache_store::MODE_SESSION, 'cache'), $sessionstore),
+            array(get_string('mode_'.cache_store::MODE_REQUEST, 'cache'), $requeststore)
+        );
+
+        $html = html_writer::start_tag('div', array('id' => 'core-cache-mode-mappings'));
+        $html .= $OUTPUT->heading(get_string('defaultmappings', 'cache'), 3);
+        $html .= html_writer::table($table);
+        $html .= html_writer::end_tag('div');
+        return $html;
     }
 
     /**

--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -98,7 +98,10 @@ class tool_forcedcache_cache_config extends cache_config {
         $stores = $this->generate_store_instance_config($config['stores']);
 
         // Generate the mode mappings.
-        $modemappings = $this->generate_mode_mapping($config['rules']);
+        if (!isset($config['modemappings'])) {
+            $config['modemappings'] = [];
+        }
+        $modemappings = $this->generate_mode_mapping($config['modemappings']);
 
         // Get the definitions.
         $definitions = $this->apply_definition_overrides(tool_forcedcache_cache_config_writer::locate_definitions(),
@@ -252,7 +255,7 @@ class tool_forcedcache_cache_config extends cache_config {
      *
      * @return array the generated default mode mappings.
      */
-    private function generate_mode_mapping() : array {
+    private function generate_mode_mapping($mappings) : array {
         // Use the defaults from core.
         $modemappings = array(
             array(
@@ -271,6 +274,18 @@ class tool_forcedcache_cache_config extends cache_config {
                 'sort' => -1
             )
         );
+
+        $modetostr = [
+            cache_store::MODE_APPLICATION => 'application',
+            cache_store::MODE_SESSION => 'session',
+            cache_store::MODE_REQUEST => 'request',
+        ];
+        foreach ($modemappings as $key => $map) {
+            $mode = $modetostr[$map['mode']];
+            if (isset($mappings[$mode])) {
+                $modemappings[$key]['store'] = $mappings[$mode];
+            }
+        }
 
         return $modemappings;
     }

--- a/lang/en/tool_forcedcache.php
+++ b/lang/en/tool_forcedcache.php
@@ -42,10 +42,10 @@ $string['store_not_ready'] = 'Error creating store {$a}, config may be incorrect
 $string['definition_overrides_title'] = 'Definition overrides';
 $string['definition_name'] = 'Definition';
 $string['definition_overrides'] = 'Overrides';
+$string['rule_default_rule'] = 'Default rule';
+$string['rule_no_rulesets'] = 'No rulesets are defined for this mode. The default store for this mode is: {$a}.';
 $string['rule_priority'] = 'Priority';
 $string['rule_ruleset'] = 'Ruleset';
-$string['rule_noconditions'] = 'No conditions set';
-$string['rule_no_rulesets'] = 'No rulesets are defined for this mode.';
 $string['store_config'] = 'Name';
 $string['store_value'] = 'Value';
 

--- a/tests/cache_config_test.php
+++ b/tests/cache_config_test.php
@@ -103,9 +103,22 @@ class tool_forcedcache_cache_config_testcase extends \advanced_testcase {
         $this->assertEquals($storereqsnotmet['expected'], $method->invoke($config, $storereqsnotmet['input']));
     }
 
-    public function test_mode_mappings () {
-        // TODO decide if we want mapping defaults forced, then test them here.
+    /**
+     * Test if default mappings return as expected.
+     */
+    public function test_default_mode_mappings() {
+        $defaultmodemappings = \tool_forcedcache_cache_config::get_default_mode_mappings();
 
+        // Read in the fixtures file for data.
+        include(__DIR__ . '/fixtures/mode_mappings_data.php');
+
+        $this->assertEquals($defaultsexpected, $defaultmodemappings);
+    }
+
+    /**
+     * Tests output of mode mpapings once rules included in the mix.
+     */
+    public function test_generated_mode_mappings_for_definitionmatchtopruleset() {
         $config = new \tool_forcedcache_cache_config();
         // Setup reflection for private function.
         $method = new \ReflectionMethod($config, 'generate_mode_mapping');
@@ -113,8 +126,27 @@ class tool_forcedcache_cache_config_testcase extends \advanced_testcase {
 
         // Read in the fixtures file for data.
         include(__DIR__ . '/fixtures/mode_mappings_data.php');
+        include(__DIR__ . '/fixtures/definition_mappings_data.php');
 
-        $this->assertEquals($defaultsexpected, $method->invoke($config, array()));
+        $expected = $generatedmodemappingagainstdefinitionmatchtoprulesetexpected;
+        $rules = $definitionmatchtopruleset['rules'];
+        $this->assertEquals($expected, $method->invoke($config, $rules));
+    }
+    /**
+     * Tests output of mode mpapings once rules included in the mix.
+     */
+    public function test_generated_mode_mappings_for_definitionnoruleset() {
+        $config = new \tool_forcedcache_cache_config();
+        // Setup reflection for private function.
+        $method = new \ReflectionMethod($config, 'generate_mode_mapping');
+        $method->setAccessible(true);
+
+        // Read in the fixtures file for data.
+        include(__DIR__ . '/fixtures/mode_mappings_data.php');
+        include(__DIR__ . '/fixtures/definition_mappings_data.php');
+
+        $rules = $definitionnoruleset['rules'];
+        $this->assertEquals($defaultsexpected, $method->invoke($config, $rules));
     }
 
     public function test_generate_definition_mappings_from_rules() {

--- a/tests/fixtures/mode_mappings_data.php
+++ b/tests/fixtures/mode_mappings_data.php
@@ -33,3 +33,23 @@ $defaultsexpected = array(
         'sort' => -1
     )
 );
+
+$generatedmodemappingagainstdefinitionmatchtoprulesetexpected = array(
+    array(
+        'mode' => cache_store::MODE_APPLICATION,
+        'store' => array(
+            'file-test'
+        ),
+        'sort' => -1
+    ),
+    array(
+        'mode' => cache_store::MODE_SESSION,
+        'store' => 'default_session',
+        'sort' => -1
+    ),
+    array(
+        'mode' => cache_store::MODE_REQUEST,
+        'store' => 'default_request',
+        'sort' => -1
+    )
+);


### PR DESCRIPTION
Closes #4 

Based on what Adam started with, I've updated it to be generated not from additional config, but from existing config, based on the broadest rule set.

Will check if there is a (final) rule set for a particular mode and apply that one as the default 'catch all'.

Unsure if an array of stores is supported, but assuming it is I've added a test for it and also updated the UI to display this information for clarity.

An example of these changes are shown below:
![image](https://user-images.githubusercontent.com/9924643/140856899-0ff605fe-2f6d-4957-8913-b9d80dafd273.png)

Running unit tests seem to be passing:
```
$ ... "tool_forcedcache\tests\tool_forcedcache_cache_config_testcase" admin/tool/forcedcache/tests/cache_config_test.php
Moodle 3.9.10+ (Build: 20210917), 235e49e5250d0dc585df137f25c164a4f1ac87e4
Php: 7.3.28, pgsql: 10.17 (Debian 10.17-1.pgdg90+1), OS: Linux 5.4.0-88-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Time: 957 ms, Memory: 64.50 MB

OK (5 tests, 17 assertions)
```

Please review the changes when available.
