### PR TITLE
Improve handling for invalid configuration state and check api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For all Moodle branches please use the master branch.
 
 1. [Clone the plugin](#step-1-clone-the-plugin)
 2. [Apply core patches (if required)](#step-2-apply-core-patches-if-required)
-3. [Wire up the configuration (if required)](#step-3-wire-up-the-configuration-if-required)
+3. [Wire up the configuration](#step-3-wire-up-the-configuration-if-required)
 4. [Update cache configurations as needed](#step-4-configure-the-cache-settings)
 5. [Apply the new cache rules](#step-5-apply-the-cache-rules)
 
@@ -56,13 +56,12 @@ Step 2: Apply core patches (if required)
 This plugin relies on [MDL-41492](https://tracker.moodle.org/browse/MDL-41492), so this patch must be applied to any Moodle prior
 to 3.9. Patches have been bundled with this plugin, to allow for quick application of the patch for various supported Moodle versions.
 
-Step 3: Wire up the configuration (if required)
+Step 3: Wire up the configuration
 -----------------------------------------------
 All configuration in this plugin is declared in code. You could do one of the following:
 - Set your configuration directly in a PHP `array` in config.php (Recommended)
 - Or Create your own configuration file (JSON), and specify the `path` to it in config.php
-- Or by updating the config.json that comes with the plugin,
-    - as the plugin loads this by default, you may skip to the next section as the following would not apply to you.
+- Or by updating the config.json that comes with the plugin, then moving it to an [appropriate location](#set-a-path-to-the-json-configuration).
 
 *Note: Only an `array` OR a `path` can be specified. It is not valid to declare both at once.*
 
@@ -193,8 +192,7 @@ If you choose to define your cache configuration in a JSON file, you will need t
 ```
 $CFG->tool_forcedcache_config_path = 'path/to/config.json';
 ```
-If this is not supplied, the plugin will default to `config.json` inside of the plugin directory.
-Once the path is decided on, the configuration can be viewed. See [Debugging](#debugging) for more information.
+If this is not supplied, the plugin will default to `config.json` inside of the plugin directory. The default is not a valid production path and this file should only serve as an example. Please move this file outside the [dirroot](https://moodle.org/mod/glossary/showentry.php?eid=20&displayformat=dictionary) directory. Once the path is decided on, the configuration can be viewed. See [Debugging](#debugging) for more information.
 
 
 Step 4: Configure the cache settings

--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -166,19 +166,20 @@ class tool_forcedcache_cache_config extends cache_config {
 
         } else if ($pathexists) {
             // Else decide on the path, then try to load it.
-            $path = $CFG->tool_forcedcache_config_path;
-        } else {
-            $path = __DIR__.'/../config.json';
+            $path = realpath($CFG->tool_forcedcache_config_path);
         }
 
         // If the json file path is inside dirroot, throw an exception. This
         // should not be allowed as it would expose the configuration.
         if (!empty($path) && strpos($path, $CFG->dirroot) !== false) {
-            throw new cache_exception(get_string('config_json_path_invalid', 'tool_forcedcache', $CFG->dirroot));
+            throw new cache_exception(get_string('config_json_path_invalid', 'tool_forcedcache', [
+                'path' => $path,
+                'dirroot' => $CFG->dirroot
+            ]));
         }
 
         // Now try to load the JSON.
-        if (file_exists($path)) {
+        if (isset($path) && file_exists($path)) {
             $filedata = file_get_contents($path);
             $config = json_decode($filedata, true);
             if (!empty($config)) {

--- a/classes/check/enabled.php
+++ b/classes/check/enabled.php
@@ -59,9 +59,10 @@ class enabled extends check {
         $dummy = new \tool_forcedcache_cache_config();
         $errors = $dummy->get_inclusion_errors();
 
-        if (empty($CFG->alternative_cache_factory_class) ||
-                $CFG->alternative_cache_factory_class !== 'tool_forcedcache_cache_factory' || !empty($errors)) {
-            $status = result::ERROR;
+        $forcedcacheenabled = isset($CFG->alternative_cache_factory_class) && $CFG->alternative_cache_factory_class === 'tool_forcedcache_cache_factory';
+
+        if (!$forcedcacheenabled || !empty($errors)) {
+            $status = $forcedcacheenabled ? result::ERROR : result::WARNING;
             $summary = get_string('page_not_active', 'tool_forcedcache');
         } else {
             $status = result::OK;

--- a/lang/en/tool_forcedcache.php
+++ b/lang/en/tool_forcedcache.php
@@ -30,8 +30,9 @@ $string['page_active'] = 'Forced cache configuration IS active.';
 // Exception Strings.
 $string['config_json_parse_fail'] = 'Error parsing JSON to array. JSON syntax may be malformed.';
 $string['config_array_parse_fail'] = 'Error parsing configuration array. Array syntax may be malformed.';
-$string['config_json_missing'] = 'Error reading specified JSON file. File may not exist, or path is incorrect.';
-$string['config_json_path_invalid'] = 'Invalid configuration path. Please ensure the path is outside of the {$a} directory.';
+$string['config_json_missing'] = 'Error reading JSON file. File may not exist, path is incorrect or path has not been set.';
+$string['config_json_path_invalid'] = 'Invalid configuration path. Please ensure the path {$a->path} is outside of the {$a->dirroot} directory.
+Please see https://github.com/catalyst/moodle-tool_forcedcache#set-a-path-to-the-json-configuration for further instructions.';
 $string['config_path_and_array'] = 'Detected both path to file and config array. Only one can be specified.';
 $string['definition_not_found'] = 'Definition not defined for configuration override: {$a}.';
 $string['store_missing_fields'] = 'Error reading store {$a}, it may be missing fields or malformed.';

--- a/tests/cache_config_test.php
+++ b/tests/cache_config_test.php
@@ -40,7 +40,7 @@ class tool_forcedcache_cache_config_testcase extends \advanced_testcase {
         $this->tmpdir = sys_get_temp_dir();
         $dest = $this->tmpdir . DIRECTORY_SEPARATOR . 'tool_forcedcache_cache_config_testcase-' . basename($source);
         copy($source, $dest);
-        return $dest;
+        return realpath($dest);
     }
 
     public function test_read_config_file_from_invalid_path() {
@@ -59,9 +59,12 @@ class tool_forcedcache_cache_config_testcase extends \advanced_testcase {
         $method->setAccessible(true);
 
         // First try loading a file in an invalid config path.
-        $CFG->tool_forcedcache_config_path = __DIR__ . '/../config.json';
+        $CFG->tool_forcedcache_config_path = realpath(__DIR__ . '/../config.json');
         $this->expectException(\cache_exception::class);
-        $this->expectExceptionMessage(get_string('config_json_path_invalid', 'tool_forcedcache', $CFG->dirroot));
+        $this->expectExceptionMessage(get_string('config_json_path_invalid', 'tool_forcedcache', [
+            'path' => $CFG->tool_forcedcache_config_path,
+            'dirroot' => $CFG->dirroot
+        ]));
         $method->invoke($config);
     }
 


### PR DESCRIPTION
- Adjust path checks to always use realpath for checking as this simplifies display, and ensures no workarounds for invalid paths are used.
- Tweak error message to show full path of invalid config (path)
- Update README and error output to link to the readme
- Updated the check api, to at most return a WARNING (instead of an
  ERROR) if the forcedcache configurations are not enabled (set as the
  alternative cache factory)

CLI:
![image](https://user-images.githubusercontent.com/9924643/147184839-23ed5f8b-caca-4d00-8dbb-4a59ecac26b2.png)

GUI:
![image](https://user-images.githubusercontent.com/9924643/147184915-f33d560d-1a35-4679-9082-93f9064fbd5c.png)

README:
https://github.com/catalyst/moodle-tool_forcedcache/blob/320227aef3faef416768dc474c4538cbecc22f96/README.md