### PR TITLE
Fix bootstrap chicken and egg condition #50

### DIFF
--- a/classes/cache_config.php
+++ b/classes/cache_config.php
@@ -113,23 +113,24 @@ class tool_forcedcache_cache_config extends cache_config {
         // Generate locks.
         $locks = $this->generate_locks();
 
-        // Get the siteidentifier. Copies pattern from cache_config.
-        // Uses 'forcedcache' if not known.
-        if (!empty($CFG->siteidentifier)) {
-            $siteidentifier = md5((string) $CFG->siteidentifier);
-        } else {
-            $siteidentifier = 'forcedcache';
-        }
-
         // Throw it all into an array and return.
-        return array(
-            'siteidentifier' => $siteidentifier,
+        $config = [
             'stores' => $stores,
             'modemappings' => $modemappings,
             'definitions' => $definitions,
             'definitionmappings' => $definitionmappings,
             'locks' => $locks
-        );
+        ];
+
+        // Get the siteidentifier. Copies pattern from cache_config.
+        // If the siteid is not yet known then we do not want it set which
+        // means the caches will be disabled further down the chain.
+        if (!empty($CFG->siteidentifier)) {
+            $config['siteidentifier'] = md5((string) $CFG->siteidentifier);
+        }
+
+        return $config;
+
     }
 
     /**

--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -60,7 +60,15 @@ class tool_forcedcache_cache_factory extends cache_factory {
             $this->configs[$class]->load();
         }
 
-        $this->set_state(self::STATE_READY);
+        // We need the siteid in order to use the caches, but the siteid
+        // is also looked up from the caches so we have a chicken and egg
+        // situation in the bootstrap. This first time we configure the
+        // caches but disable them so the siteid can warm up correctly.
+        if (empty($CFG->siteidentifier)) {
+            $this->set_state(self::STATE_STORES_DISABLED);
+        } else {
+            $this->set_state(self::STATE_READY);
+        }
 
         // Return the instance.
         return $this->configs[$class];


### PR DESCRIPTION
Backporting https://github.com/catalyst/moodle-tool_forcedcache/pull/51 to `master` branch

Tested and working as expected on Totara 13 & Moodle 3.9