### PR TITLE
[#54] Re-enable caches properly

### DIFF
--- a/classes/cache_factory.php
+++ b/classes/cache_factory.php
@@ -68,7 +68,10 @@ class tool_forcedcache_cache_factory extends cache_factory {
         if (empty($CFG->siteidentifier)) {
             $this->set_state(self::STATE_STORES_DISABLED);
         } else {
-            $this->set_state(self::STATE_READY);
+            // We cannot directly set the state to enabled from disabled.
+            // So we instead start and finish an update.
+            $this->updating_started();
+            $this->updating_finished();
         }
 
         // Return the instance.


### PR DESCRIPTION
Closes #54 

**The issue**
We discovered that if you set the stores to disabled, but then re-enable them later in the script, the re-enable is ignored:

https://github.com/moodle/moodle/blob/e0a9cf22889c2f98fda5b0acd515567ff29f6b78/cache/classes/factory.php#L557

So our fix in #50 wasn't actually re-enabling it as we intended it to. And because the cache factory instance is static, the disable persisted for the entire script call.

**The fix**
- We can simply emulate an 'update' to the cache to re-enable it. This means we don't need to change any core code.

**Testing**
- Comment out the code that bootstraps the siteidentifier. This was originally masking the issue because it meant the siteidentifier was always available at the start (so the stores never got disabled)
- https://github.com/moodle/moodle/blob/main/lib/setup.php#L713-L737
- Go to cache store page and confirm reloading the page that the stores are not disabled